### PR TITLE
cmake: Add missing files required to build linux driver to cmake install

### DIFF
--- a/ajadriver/CMakeLists.txt
+++ b/ajadriver/CMakeLists.txt
@@ -21,6 +21,7 @@ if (AJA_BUILD_OPENSOURCE)
     file(WRITE mac/README.md ${WIN_MAC_MIT_DRIVER_README})
 endif()
 
+# ajadriver
 set(AJADRIVER_COMMON_HEADERS
     ntv2anc.h
     ntv2audio.h
@@ -48,7 +49,6 @@ set(AJADRIVER_COMMON_HEADERS
     ntv2vpid.h
     ntv2xpt.h
     ntv2xptlookup.h)
-
 set(AJADRIVER_COMMON_SOURCES
     ntv2anc.c
     ntv2audio.c
@@ -71,85 +71,96 @@ set(AJADRIVER_COMMON_SOURCES
     ntv2vpid.c
     ntv2xpt.c)
 
+# ajadriver/linux
+set(AJADRIVER_LINUX_HEADERS
+    linux/driverdbg.h
+    linux/fs1wait.h
+    linux/hevccommand.h
+    linux/hevccommon.h
+    linux/hevcconstants.h
+    linux/hevcdriver.h
+    linux/hevcinterrupt.h
+    linux/hevcparams.h
+    linux/hevcpublic.h
+    linux/hevcregister.h
+    linux/hevcstream.h
+    linux/ntv2dma.h
+    linux/ntv2driverautocirculate.h
+    linux/ntv2driverbigphysarea.h
+    linux/ntv2driverdbgmsgctl.h
+    linux/ntv2driver.h
+    linux/ntv2driverstatus.h
+    linux/ntv2drivertask.h
+    linux/ntv2kona2.h
+    linux/ntv2serial.h
+    linux/registerio.h)
+set(AJADRIVER_LINUX_SOURCES
+    linux/hevcapi.c
+    linux/hevccommand.c
+    linux/hevcdriver.c
+    linux/hevcinterrupt.c
+    linux/hevcparams.c
+    linux/hevcregister.c
+    linux/hevcstream.c
+    linux/ntv2dma.c
+    linux/ntv2driverautocirculate.c
+    linux/ntv2driver.c
+    linux/ntv2driverdbgmsgctl.c
+    linux/ntv2driverstatus.c
+    linux/ntv2drivertask.c
+    linux/ntv2kona2.c
+    linux/ntv2serial.c
+    linux/registerio.c)
+set(AJADRIVER_LINUX_BUILD_FILES
+    linux/Makefile
+    linux/nvidia-ko-to-module-symvers)
+set(AJADRIVER_LINUX_LOAD_FILES
+    ${AJA_LIBRARIES_ROOT}/bin/load_ajantv2
+    ${AJA_LIBRARIES_ROOT}/bin/unload_ajantv2)
+# ajadriver target sources
 set(AJADRIVER_TARGET_SOURCES
     ${AJADRIVER_COMMON_HEADERS}
     ${AJADRIVER_COMMON_SOURCES})
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    if (AJA_BUILD_OPENSOURCE AND AJA_INSTALL_SOURCES)
-        install(FILES win/README.md DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/win)
-    endif()
+    message("Windows driver CMake build not yet implemented!")
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    if (AJA_BUILD_OPENSOURCE AND AJA_INSTALL_SOURCES)
-        install(FILES mac/README.md DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/mac)
-    endif()
+    message("macOS driver CMake build not yet implemented!")
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(AJADRIVER_LINUX_BUILD_FILES
-        linux/Makefile
-        linux/nvidia-ko-to-module-symvers)
-    set(AJADRIVER_LINUX_LOAD_FILES
-        ${AJA_LIBRARIES_ROOT}/bin/load_ajantv2
-        ${AJA_LIBRARIES_ROOT}/bin/unload_ajantv2)
-    set(AJADRIVER_LINUX_HEADERS
-        linux/driverdbg.h
-        linux/fs1wait.h
-        linux/hevccommand.h
-        linux/hevccommon.h
-        linux/hevcconstants.h
-        linux/hevcdriver.h
-        linux/hevcinterrupt.h
-        linux/hevcparams.h
-        linux/hevcpublic.h
-        linux/hevcregister.h
-        linux/hevcstream.h
-        linux/ntv2dma.h
-        linux/ntv2driverautocirculate.h
-        linux/ntv2driverbigphysarea.h
-        linux/ntv2driverdbgmsgctl.h
-        linux/ntv2driver.h
-        linux/ntv2driverstatus.h
-        linux/ntv2drivertask.h
-        linux/ntv2kona2.h
-        linux/ntv2serial.h
-        linux/registerio.h)
-    set(AJADRIVER_LINUX_SOURCES
-        linux/hevcapi.c
-        linux/hevccommand.c
-        linux/hevcdriver.c
-        linux/hevcinterrupt.c
-        linux/hevcparams.c
-        linux/hevcregister.c
-        linux/hevcstream.c
-        linux/ntv2dma.c
-        linux/ntv2driverautocirculate.c
-        linux/ntv2driver.c
-        linux/ntv2driverdbgmsgctl.c
-        linux/ntv2driverstatus.c
-        linux/ntv2drivertask.c
-        linux/ntv2kona2.c
-        linux/ntv2serial.c
-        linux/registerio.c)
     set(AJADRIVER_TARGET_SOURCES
         ${AJADRIVER_TARGET_SOURCES}
         ${AJADRIVER_LINUX_HEADERS}
         ${AJADRIVER_LINUX_SOURCES})
-
-    if (AJA_INSTALL_HEADERS)
-        install(FILES ${AJADRIVER_LINUX_HEADERS} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
-    endif()
-    if (AJA_INSTALL_SOURCES)
-        install(FILES ${AJADRIVER_LINUX_SOURCES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
-        install(FILES ${AJADRIVER_LINUX_BUILD_FILES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
-        install(FILES ${AJADRIVER_LINUX_LOAD_FILES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajalibraries/bin)
-    endif()
 endif()
 
-add_custom_target(ajadriver ${AJADRIVER_TARGET_SOURCES})
-add_dependencies(ajadriver install)
+add_custom_target(ajadriver_install ${AJADRIVER_TARGET_SOURCES})
+add_dependencies(ajadriver_install install)
 
+# Windows
+if (AJA_BUILD_OPENSOURCE AND AJA_INSTALL_SOURCES)
+    install(FILES win/README.md DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/win)
+endif()
+# macOS
+if (AJA_BUILD_OPENSOURCE AND AJA_INSTALL_SOURCES)
+    install(FILES mac/README.md DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/mac)
+endif()
+# Linux
+if (AJA_INSTALL_HEADERS)
+    install(FILES ${AJADRIVER_LINUX_HEADERS} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
+endif()
+if (AJA_INSTALL_SOURCES)
+    install(FILES ${AJADRIVER_LINUX_SOURCES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
+    install(FILES ${AJADRIVER_LINUX_BUILD_FILES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver/linux)
+    install(FILES ${AJADRIVER_LINUX_LOAD_FILES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajalibraries/bin)
+    install(FILES ${AJA_CMAKE_DIR}/../build/sdkversion.mk DESTINATION ${AJA_INSTALL_INCLUDEDIR}/build)
+    install(FILES ${AJA_CMAKE_DIR}/../build/configure.mk DESTINATION ${AJA_INSTALL_INCLUDEDIR}/build)
+endif()
+# common
 if (AJA_INSTALL_HEADERS)
     install(FILES ${AJADRIVER_COMMON_HEADERS} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver)
+    install(FILES ${AJA_LIB_NTV2_ROOT}/includes/ntv2driverprocamp.h DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajalibraries/ajantv2/includes)
 endif()
 if (AJA_INSTALL_SOURCES)
     install(FILES ${AJADRIVER_COMMON_SOURCES} DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajadriver)
+    install(FILES ${AJA_LIB_NTV2_ROOT}/src/ntv2driverprocamp.cpp DESTINATION ${AJA_INSTALL_INCLUDEDIR}/ajalibraries/ajantv2/src)
 endif()


### PR DESCRIPTION
The CMakeLists.txt for ajadriver was missing files in the cmake install command required to build the driver. This PR will copy the requisite files to the proper locations when running `cmake --install ajadriver`.