### PR TITLE
Compilation fixes and memory corruption prevention

### DIFF
--- a/ajadriver/linux/ntv2devicefeatures.c
+++ b/ajadriver/linux/ntv2devicefeatures.c
@@ -1,0 +1,1 @@
+/home/daniel/ntv2/ajalibraries/ajantv2/src/ntv2devicefeatures.cpp

--- a/ajadriver/linux/ntv2driverprocamp.c
+++ b/ajadriver/linux/ntv2driverprocamp.c
@@ -1,0 +1,1 @@
+/home/daniel/ntv2/ajalibraries/ajantv2/src/ntv2driverprocamp.cpp

--- a/ajadriver/linux/ntv2vpidfromspec.c
+++ b/ajadriver/linux/ntv2vpidfromspec.c
@@ -1,0 +1,1 @@
+/home/daniel/ntv2/ajalibraries/ajantv2/src/ntv2vpidfromspec.cpp

--- a/ajalibraries/ajabase/common/buffer.cpp
+++ b/ajalibraries/ajabase/common/buffer.cpp
@@ -72,10 +72,13 @@ AJABuffer::AllocateBuffer(size_t size, size_t alignment, char* pName)
 
 		ComputeAlignment();
 		
-		size_t nameLen = strlen(pName);
+		const size_t nameLen = strlen(pName);
 		mpAllocateName = new char[nameLen + 1];
 		AJA_ASSERT(mpAllocateName != NULL);
-		strncpy(mpAllocateName, pName, nameLen);
+
+		memcpy(mpAllocateName, pName, nameLen);
+		mpAllocateName[nameLen] = '\0';
+
 	}
 	// allocate a non shared buffer
 	else

--- a/ajalibraries/ajantv2/includes/ntv2devicefeatures.h
+++ b/ajalibraries/ajantv2/includes/ntv2devicefeatures.h
@@ -9,10 +9,6 @@
 #ifndef NTV2DEVICEFEATURES_H
 #define NTV2DEVICEFEATURES_H
 
-#if defined(AJALinux) || defined(AJA_LINUX)
-	#include <stddef.h>		// For size_t
-#endif
-
 #include "ajaexport.h"
 #include "ajatypes.h"
 #include "ntv2enums.h"

--- a/ajalibraries/ajantv2/includes/ntv2driverprocamp.h
+++ b/ajalibraries/ajantv2/includes/ntv2driverprocamp.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT */
+/**
+	@file		ntv2driverprocamp.h
+	@brief		Declares functions used in the NTV2 device driver.
+	@copyright	(C) 2004-2021 AJA Video Systems, Inc.  All rights reserved.
+**/
+// ntv2driverprocamp.h
+#ifndef NTV2DRIVERPROCAMP_H
+#define NTV2DRIVERPROCAMP_H
+
+#include "ajatypes.h"
+#include "ntv2enums.h"
+#include "ntv2publicinterface.h"
+
+// This file is used by the Linux driver which is C, not C++.
+#if defined(__CPLUSPLUS__) || defined(__cplusplus)
+#else
+#define false (0)
+#define true (!false)
+#endif
+
+#ifdef AJALinux
+#include "ntv2linuxpublicinterface.h"
+#endif
+
+#ifdef AJAMac
+	#include <IOKit/IOTypes.h>
+	#include "ntv2macpublicinterface.h"
+#endif
+
+#ifdef MSWindows
+#include "ntv2winpublicinterface.h"
+#endif
+
+
+bool SetVirtualProcampRegister(	VirtualRegisterNum virtualRegisterNum, 
+								ULWord value, 
+								VirtualProcAmpRegisters *regs);
+
+bool GetVirtualProcampRegister(	VirtualRegisterNum virtualRegisterNum, 
+								ULWord *value, 
+								VirtualProcAmpRegisters *regs);
+
+#ifndef AJAMac		// note: in Mac-land these are methods in MacDriver.h
+
+bool WriteHardwareProcampRegister(	ULWord inDeviceIndex,
+									NTV2DeviceID deviceID,
+									VirtualRegisterNum virtualRegisterNum, 
+									ULWord value, 
+									HardwareProcAmpRegisterImage *hwRegImage);
+									
+bool RestoreHardwareProcampRegisters(	ULWord inDeviceIndex,
+										NTV2DeviceID deviceID,
+										VirtualProcAmpRegisters *regs,
+										HardwareProcAmpRegisterImage *hwRegImage);
+
+bool I2CWriteDataSingle(ULWord inDeviceIndex, UByte I2CAddress, UByte I2CData);
+
+bool I2CWriteDataDoublet(	ULWord inDeviceIndex,
+						UByte I2CAddress1, UByte I2CData1,
+						UByte I2CAddress2, UByte I2CData2);
+						
+#endif	// !AJAMac
+
+#endif	// NTV2DRIVERPROCAMP_H

--- a/ajalibraries/ajantv2/src/ntv2config2022.cpp
+++ b/ajalibraries/ajantv2/src/ntv2config2022.cpp
@@ -1623,7 +1623,7 @@ bool CNTV2Config2022::GetLinkStatus(eSFP sfp, SFPStatus & sfpStatus)
 
 bool CNTV2Config2022::Get2022ChannelRxStatus(NTV2Channel channel, s2022RxChannelStatus & chanStatus)
 {
-	uint32_t addr;
+	uint32_t addr = 0;
 
 	SelectRxChannel(channel, SFP_2, addr);
 	ReadChannelRegister(addr + kReg2022_6_rx_sec_recv_pkt_cnt, &chanStatus.sfp2RxPackets);

--- a/ajalibraries/ajantv2/src/ntv2discover.cpp
+++ b/ajalibraries/ajantv2/src/ntv2discover.cpp
@@ -82,9 +82,11 @@ extractBoardInventory(NTV2NubPkt *pPkt, NTV2DiscoverRespPayload *boardInventory,
 		dbi->boardID = ntohl(dbi->boardID);
 		char tmp[NTV2_DISCOVER_BOARDINFO_DESC_STRMAX];
 		// Prepend peername to description.
-		strncpy(tmp, dbi->description, NTV2_DISCOVER_BOARDINFO_DESC_STRMAX);
 
-		int peernameLen = snprintf( dbi->description, 
+		strncpy(tmp, dbi->description, NTV2_DISCOVER_BOARDINFO_DESC_STRMAX - 1);		
+		tmp[sizeof tmp - 1] = '\0';
+
+		int peernameLen = snprintf(	dbi->description, 
 									NTV2_DISCOVER_BOARDINFO_DESC_STRMAX, 
 									"%s: ", peername);
 

--- a/ajalibraries/ajantv2/src/ntv2driverinterface.cpp
+++ b/ajalibraries/ajantv2/src/ntv2driverinterface.cpp
@@ -990,7 +990,7 @@ bool CNTV2DriverInterface::BitstreamStatus (NTV2ULWordVector & outRegValues)
 void CNTV2DriverInterface::FinishOpen (void)
 {
 	// HACK! FinishOpen needs frame geometry to determine frame buffer size and number.
-	NTV2FrameGeometry fg;
+	NTV2FrameGeometry fg{};
 	ULWord val1(0), val2(0);
 	ReadRegister (kRegGlobalControl, fg, kRegMaskGeometry, kRegShiftGeometry);	//	Read FrameGeometry
 	ReadRegister (kRegCh1Control, val1, kRegMaskFrameFormat, kRegShiftFrameFormat); //	Read PixelFormat
@@ -1075,10 +1075,18 @@ bool CNTV2DriverInterface::ParseFlashHeader (BITFILE_INFO_STRUCT & bitFileInfo)
 	headerError = fileInfo.ParseHeaderFromBuffer(bitFileHdrBuffer);
 	if (headerError.empty())
 	{
-		::strncpy(bitFileInfo.dateStr, fileInfo.GetDate().c_str(), NTV2_BITFILE_DATETIME_STRINGLENGTH);
-		::strncpy(bitFileInfo.timeStr, fileInfo.GetTime().c_str(), NTV2_BITFILE_DATETIME_STRINGLENGTH);
-		::strncpy(bitFileInfo.designNameStr, fileInfo.GetDesignName().c_str(), NTV2_BITFILE_DESIGNNAME_STRINGLENGTH);
-		::strncpy(bitFileInfo.partNameStr, fileInfo.GetPartName().c_str(), NTV2_BITFILE_PARTNAME_STRINGLENGTH);
+		::strncpy(bitFileInfo.dateStr, fileInfo.GetDate().c_str(), NTV2_BITFILE_DATETIME_STRINGLENGTH - 1);
+		bitFileInfo.dateStr[NTV2_BITFILE_DATETIME_STRINGLENGTH - 1] = '\0';
+
+		::strncpy(bitFileInfo.timeStr, fileInfo.GetTime().c_str(), NTV2_BITFILE_DATETIME_STRINGLENGTH - 1);
+		bitFileInfo.timeStr[NTV2_BITFILE_DATETIME_STRINGLENGTH - 1] = '\0';
+
+		::strncpy(bitFileInfo.designNameStr, fileInfo.GetDesignName().c_str(), NTV2_BITFILE_DESIGNNAME_STRINGLENGTH - 1);
+		bitFileInfo.designNameStr[NTV2_BITFILE_DESIGNNAME_STRINGLENGTH - 1] = '\0';
+
+		::strncpy(bitFileInfo.partNameStr, fileInfo.GetPartName().c_str(), NTV2_BITFILE_PARTNAME_STRINGLENGTH - 1);
+		bitFileInfo.partNameStr[NTV2_BITFILE_PARTNAME_STRINGLENGTH - 1] = '\0';
+
 		bitFileInfo.numBytes = ULWord(fileInfo.GetProgramStreamLength());
 	}
 	return headerError.empty();

--- a/ajalibraries/ajantv2/src/ntv2driverprocamp.cpp
+++ b/ajalibraries/ajantv2/src/ntv2driverprocamp.cpp
@@ -1,0 +1,764 @@
+/* SPDX-License-Identifier: MIT */
+/**
+	@file		ntv2driverprocamp.cpp
+	@brief		Implementation of driver procamp utility functions.
+	@copyright	(C) 2003-2021 AJA Video Systems, Inc.
+	@note		Because this module is compiled into the driver, it must remain straight ANSI 'C' -- no C++ or STL.
+				Since the Linux driver is not C++ based, a devicenumber is required in some functions in place of "this" pointer.
+**/
+
+#include "ntv2driverprocamp.h"
+#if defined(NTV2_BUILDING_DRIVER)
+
+#ifdef AJALinux
+#include <linux/jiffies.h>
+#include "registerio.h"
+#include "driverdbg.h"
+#include "ntv2driverdbgmsgctl.h"
+#define ENABLE_DEBUG_PRINT
+#endif
+
+#ifdef AJAMac
+	#include <IOKit/IOLib.h>
+	#include "MacDriver.h"
+	
+	#define MSG IOLog
+	#define MsgsEnabled(x)	(false)		// set this to 'true' to enable debug IOLogs
+	#define ENABLE_DEBUG_PRINT
+#endif
+
+
+
+typedef enum
+{
+	isSDProc,
+	isHDProc
+} SDIProcType;
+
+#ifndef AJAMac		// see MacDriver.h
+	static bool I2CWriteData(ULWord deviceNumber, ULWord value);
+	static bool I2CWriteControl(ULWord deviceNumber, ULWord value);
+	static bool WaitForI2CReady(ULWord deviceNumber);
+	static bool I2CInhibitHardwareReads(ULWord deviceNumber);
+	static bool I2CEnableHardwareReads(ULWord deviceNumber);
+#endif	
+
+
+
+/*****************************************************************************************
+ *	SetVirtualProcampRegister
+ *****************************************************************************************/
+bool SetVirtualProcampRegister(	VirtualRegisterNum virtualRegisterNum, 
+								ULWord value, 
+								VirtualProcAmpRegisters *regs)
+{
+
+#ifdef ENABLE_DEBUG_PRINT
+	if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+		MSG("Got set of procamp vreg %d, value 0x%x\n", virtualRegisterNum, value);
+#endif
+
+	switch (virtualRegisterNum) 
+	{
+		case kVRegProcAmpSDRegsInitialized:
+			regs->SD.initialized = value;
+			break;
+
+		case kVRegProcAmpStandardDefBrightness:
+			regs->SD.brightness = value;
+			break;
+
+		case kVRegProcAmpStandardDefContrast:
+			regs->SD.contrast = value;
+			break;
+
+		case kVRegProcAmpStandardDefSaturation:
+			regs->SD.saturationCb = value;
+			regs->SD.saturationCr = value;
+			break;
+
+		case kVRegProcAmpStandardDefHue:
+			regs->SD.hue = value;
+			break;
+
+		case kVRegProcAmpStandardDefCbOffset:
+			regs->SD.CbOffset = value;
+			break;
+
+		case kVRegProcAmpStandardDefCrOffset:
+			regs->SD.CrOffset = value;
+			break;
+
+		case kVRegProcAmpHDRegsInitialized:
+			regs->HD.initialized = value;
+			break;
+
+		case kVRegProcAmpHighDefContrast:
+			regs->HD.contrast = value;
+			break;
+
+		case kVRegProcAmpHighDefSaturationCb:
+			regs->HD.saturationCb = value;
+			break;
+
+		case kVRegProcAmpHighDefSaturationCr:
+			regs->HD.saturationCr = value;
+			break;
+
+		case kVRegProcAmpHighDefBrightness:
+			regs->HD.brightness = value;
+			break;
+
+		case kVRegProcAmpHighDefCbOffset:
+			regs->HD.CbOffset = value;
+			break;
+
+		case kVRegProcAmpHighDefCrOffset:
+			regs->HD.CrOffset = value;
+			break;
+
+		case kVRegProcAmpHighDefHue:	// Not supported in hardware
+			return false;	
+
+		default:
+			return false;	
+	}
+
+	return true;
+}
+
+
+/*****************************************************************************************
+ *	GetVirtualProcampRegister
+ *****************************************************************************************/
+bool GetVirtualProcampRegister(	VirtualRegisterNum virtualRegisterNum, 
+								ULWord *value, 
+								VirtualProcAmpRegisters *regs)
+{
+#ifdef ENABLE_DEBUG_PRINT
+	if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+		MSG("Got get of procamp vreg %d, fetching value\n", virtualRegisterNum);
+#endif
+
+	switch (virtualRegisterNum) 
+	{
+		case kVRegProcAmpSDRegsInitialized:
+			*value = regs->SD.initialized;
+			break;
+
+		case kVRegProcAmpStandardDefBrightness:
+			*value = regs->SD.brightness;
+			break;
+
+		case kVRegProcAmpStandardDefContrast:
+			*value = regs->SD.contrast;
+			break;
+
+		case kVRegProcAmpStandardDefSaturation:
+			if (regs->SD.saturationCb != regs->SD.saturationCr)
+				return false;
+			*value = regs->SD.saturationCb;
+			break;
+
+		case kVRegProcAmpStandardDefHue:
+			*value = regs->SD.hue;
+			break;
+
+		case kVRegProcAmpStandardDefCbOffset:
+			*value = regs->SD.CbOffset;
+			break;
+
+		case kVRegProcAmpStandardDefCrOffset:
+			*value = regs->SD.CrOffset;
+			break;
+
+		case kVRegProcAmpHDRegsInitialized:
+			*value = regs->HD.initialized;
+			break;
+
+		case kVRegProcAmpHighDefContrast:
+			*value = regs->HD.contrast;
+			break;
+
+		case kVRegProcAmpHighDefSaturationCb:
+			*value = regs->HD.saturationCb;
+			break;
+
+		case kVRegProcAmpHighDefSaturationCr:
+			*value = regs->HD.saturationCr;
+			break;
+
+		case kVRegProcAmpHighDefBrightness:
+			*value = regs->HD.brightness;
+			break;
+
+		case kVRegProcAmpHighDefCbOffset:
+			*value = regs->HD.CbOffset;
+			break;
+
+		case kVRegProcAmpHighDefCrOffset:
+			*value = regs->HD.CrOffset;
+			break;
+
+		case kVRegProcAmpHighDefHue:
+			return false;	// Not supported
+
+		default:
+			return false;	// Not supported
+	}
+
+#ifdef ENABLE_DEBUG_PRINT
+	if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+		MSG("Got get of procamp vreg %d, value 0x%x\n", virtualRegisterNum, *value);
+#endif
+	return true;
+}
+
+
+/*****************************************************************************************
+ *	RestoreHardwareProcampRegisters
+ *****************************************************************************************/
+// Call this function to restore ProcAmp registers (from virtual register)
+
+
+#ifdef AJAMac  
+bool MacDriver::RestoreHardwareProcampRegisters(	ULWord deviceNumber,
+													NTV2DeviceID deviceID,
+													VirtualProcAmpRegisters *regs,
+													HardwareProcAmpRegisterImage *hwRegImage)
+#else
+bool RestoreHardwareProcampRegisters(	ULWord deviceNumber,
+										NTV2DeviceID deviceID,
+										VirtualProcAmpRegisters *regs,
+										HardwareProcAmpRegisterImage *hwRegImage)
+#endif
+{
+	ULWord regVal;
+	ULWord regNum;
+	
+	// If SD controls initialized
+	if ( GetVirtualProcampRegister( (VirtualRegisterNum)kVRegProcAmpSDRegsInitialized, &regVal, regs ) && regVal != 0)
+	{
+		for ( regNum = (ULWord)kVRegProcAmpStandardDefBrightness; regNum < (ULWord)kVRegProcAmpEndStandardDefRange; regNum++ )
+		{
+			// Fetch cached value and skip unsupported registers
+			if ( GetVirtualProcampRegister( (VirtualRegisterNum)regNum, &regVal, regs ) )
+			{
+				if (!WriteHardwareProcampRegister( deviceNumber, deviceID, (VirtualRegisterNum)regNum, regVal, hwRegImage ))
+				{
+					return false;
+				}
+			}
+		}
+	}
+
+	// If HD controls initialized
+	if ( GetVirtualProcampRegister( (VirtualRegisterNum)kVRegProcAmpHDRegsInitialized, &regVal, regs ) && regVal != 0)
+	{
+		for ( regNum = (ULWord)kVRegProcAmpHighDefBrightness; regNum < (ULWord)kVRegProcAmpEndHighDefRange; regNum++ )
+		{
+			// Fetch cached value and skip unsupported registers
+			if ( GetVirtualProcampRegister( (VirtualRegisterNum)regNum, &regVal, regs ) )
+			{
+				if (!WriteHardwareProcampRegister( deviceNumber, deviceID, (VirtualRegisterNum)regNum, regVal, hwRegImage ))
+				{
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}
+
+
+
+/*****************************************************************************************
+ *	WriteHardwareProcampRegister
+ *****************************************************************************************/
+// This function is necessary because:
+// 1) We can't read the I2C registers and
+// 2) The HD registers are spread across various I2C addresses
+//  
+#ifdef AJAMac  
+bool MacDriver::WriteHardwareProcampRegister(	ULWord deviceNumber,
+												NTV2DeviceID deviceID,
+												VirtualRegisterNum virtualRegisterNum, 
+												ULWord value, 
+												HardwareProcAmpRegisterImage *hwRegImage)
+#else
+bool WriteHardwareProcampRegister(	ULWord deviceNumber,
+									NTV2DeviceID deviceID,
+									VirtualRegisterNum virtualRegisterNum, 
+									ULWord value, 
+									HardwareProcAmpRegisterImage *hwRegImage)
+#endif
+{
+	ULWord mask;
+
+#ifdef ENABLE_DEBUG_PRINT
+	if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+		MSG("Got write to hw reg of procamp vreg %d, value 0x%x\n", virtualRegisterNum, value);
+#endif
+
+	// Fetch mask.
+	switch (virtualRegisterNum) 
+	{
+		case kVRegProcAmpStandardDefBrightness:
+		case kVRegProcAmpStandardDefContrast:
+		case kVRegProcAmpStandardDefSaturation:
+		case kVRegProcAmpStandardDefHue:
+		case kVRegProcAmpStandardDefCbOffset:
+		case kVRegProcAmpStandardDefCrOffset:
+			return false;
+			break;
+
+		case kVRegProcAmpHighDefContrast:
+		case kVRegProcAmpHighDefSaturationCb:
+		case kVRegProcAmpHighDefSaturationCr:
+		case kVRegProcAmpHighDefBrightness:
+		case kVRegProcAmpHighDefCbOffset:
+		case kVRegProcAmpHighDefCrOffset:
+			return false;
+			break;
+
+		case kVRegProcAmpHighDefHue:		// Not supported in hardware.
+			return false;
+
+		default:						// Other non-procamp virtual regs
+			return false;
+	}
+
+	value &= mask;	// Note: We may be nuking some high bits from a previously signed value to shoehorn it into a hw register
+
+	switch (virtualRegisterNum) 
+	{
+		case kVRegProcAmpStandardDefBrightness:
+			hwRegImage->SD.brightness = value;
+			return I2CWriteDataSingle(deviceNumber, kRegADV7189BBrightness, hwRegImage->SD.brightness);
+
+		case kVRegProcAmpStandardDefContrast:
+			hwRegImage->SD.contrast= value;
+			return I2CWriteDataSingle(deviceNumber, kRegADV7189BContrast, hwRegImage->SD.contrast);
+
+		case kVRegProcAmpStandardDefSaturation:
+			hwRegImage->SD.saturationCb = value;
+			hwRegImage->SD.saturationCr = value;
+			return I2CWriteDataDoublet(	deviceNumber, 
+									kRegADV7189BSaturationCb, hwRegImage->SD.saturationCb, 
+									kRegADV7189BSaturationCr, hwRegImage->SD.saturationCr);
+
+		case kVRegProcAmpStandardDefHue:
+			hwRegImage->SD.hue = value;
+			return I2CWriteDataSingle(deviceNumber, kRegADV7189BHue, hwRegImage->SD.hue);
+
+		case kVRegProcAmpStandardDefCbOffset:
+			hwRegImage->SD.CbOffset = value;
+			return I2CWriteDataSingle(deviceNumber, kRegADV7189BCbOffset, hwRegImage->SD.CbOffset);
+
+		case kVRegProcAmpStandardDefCrOffset:
+			hwRegImage->SD.CrOffset = value;
+			return I2CWriteDataSingle(deviceNumber, kRegADV7189BCrOffset, hwRegImage->SD.CrOffset);
+
+		// The high def regs are scattered across various I2C addresses.
+		// Messy.
+		// TODO: If performance response is sluggish, a possible optimization is 
+		// to write only register(s) that change.  I2C writes are slow, 100uSec.
+		// Maybe fast enough... 
+		case kVRegProcAmpHighDefContrast:
+			hwRegImage->HD.hex73 = BIT_7 | BIT_6 | (value >> 4); 
+			hwRegImage->HD.hex74 &= 0x0f;		// Preserve saturation Cb portion	
+			hwRegImage->HD.hex74 |= (value & 0x0f) << 4;
+			return I2CWriteDataDoublet(	deviceNumber, 
+									0x73, hwRegImage->HD.hex73, 
+									0x74, hwRegImage->HD.hex74);
+
+		case kVRegProcAmpHighDefSaturationCb:
+			hwRegImage->HD.hex74 &= 0xf0;		// Preserve contrast portion
+			hwRegImage->HD.hex74 |= value >> 6;
+			hwRegImage->HD.hex75 &= 0x03;		// Preserve saturation Cr portion
+			hwRegImage->HD.hex75 |= (value & 0x3f) <<2;
+			return I2CWriteDataDoublet(	deviceNumber,
+									0x74, hwRegImage->HD.hex74, 
+									0x75, hwRegImage->HD.hex75);
+
+		case kVRegProcAmpHighDefSaturationCr:
+			hwRegImage->HD.hex75 &= 0xfc;		// Preserve Saturation Cb portion
+			hwRegImage->HD.hex75 |= value >> 8;
+			hwRegImage->HD.hex76 = value & 0xff;	
+			return I2CWriteDataDoublet(	deviceNumber,
+									0x75, hwRegImage->HD.hex75, 
+									0x76, hwRegImage->HD.hex76);
+
+		case kVRegProcAmpHighDefBrightness:
+			hwRegImage->HD.hex77 = value  >> 4; // Bits 7, 6 should be clear
+			hwRegImage->HD.hex78 &= 0x0f;		// Preserve Cb Offset portion
+			hwRegImage->HD.hex78 |= (value & 0x0f) << 4;
+			return I2CWriteDataDoublet(	deviceNumber,
+									0x77, hwRegImage->HD.hex77, 
+									0x78, hwRegImage->HD.hex78);
+
+		case kVRegProcAmpHighDefCbOffset:
+			hwRegImage->HD.hex78 &= 0xf0; 		// Preserve brightness portion
+			hwRegImage->HD.hex78 |= value  >> 6; 
+			hwRegImage->HD.hex79 &= 0x03;		// Preserve Cr Offset portion
+			hwRegImage->HD.hex79 |= (value & 0x3f) << 2;
+			return I2CWriteDataDoublet(	deviceNumber,
+									0x78, hwRegImage->HD.hex78, 
+									0x79, hwRegImage->HD.hex79);
+
+		case kVRegProcAmpHighDefCrOffset:
+			hwRegImage->HD.hex79 &= 0xfc;		// Preserve Cb offset portion 
+			hwRegImage->HD.hex79 |= value  >> 8; 
+			hwRegImage->HD.hex7A = value & 0xff;
+			return I2CWriteDataDoublet(	deviceNumber,
+									0x79, hwRegImage->HD.hex79, 
+									0x7A, hwRegImage->HD.hex7A);
+
+		case kVRegProcAmpHighDefHue: 			// Hardware doesn't support HD hue adjust
+			return false;
+
+		default:								// Other non-procamp virtual regs
+			return false;
+	}
+
+	return true;
+}
+
+
+/*****************************************************************************************
+ *	I2CWriteDataSingle
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CWriteDataSingle(ULWord deviceNumber, UByte I2CAddress, UByte I2CData)
+#else
+bool I2CWriteDataSingle(ULWord deviceNumber, UByte I2CAddress, UByte I2CData)
+#endif
+{
+	ULWord I2CCommand = I2CAddress;
+	bool retVal;
+
+	if (!I2CInhibitHardwareReads(deviceNumber))
+	{
+		retVal = false;
+		goto bail;
+	}
+
+	I2CCommand <<= 8;
+	I2CCommand |= I2CData;
+	
+	retVal = I2CWriteData(deviceNumber, I2CCommand);
+
+bail:
+	if(!I2CEnableHardwareReads(deviceNumber))
+		retVal = false;
+
+	return retVal;
+}
+
+
+/*****************************************************************************************
+ *	I2CInhibitHardwareReads
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CInhibitHardwareReads(ULWord deviceNumber)
+#else
+static bool I2CInhibitHardwareReads(ULWord deviceNumber)
+#endif
+{
+	bool retVal = true;
+
+	// Unspecified bad things can happen if I2C double writes are
+	// interfered with.  Guard access with a mutex.
+#ifdef AJALinux
+	NTV2PrivateParams *pNTV2Params;
+
+	pNTV2Params = getNTV2Params(deviceNumber);
+
+	if(down_interruptible(&pNTV2Params->_I2CMutex))
+	{
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CInhibitHardwareReads: down_interruptible() failed.\n");
+		return false;	
+	}
+#endif
+
+#ifdef AJAMac
+	// We're assuming that this will only be called from INSIDE the IOCommandGate, so we're already protected from pre-emption
+#endif
+
+
+	if(!I2CWriteControl(deviceNumber, BIT(16)))		// Inhibit I2C status register reads at vertical
+	{		 
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CInhibitHardwareReads: WriteControl() failed.\n");
+#endif
+		retVal = false;
+		
+		I2CWriteControl(deviceNumber, 0);			// Enable I2C status register reads at vertical
+	}
+	else
+	{
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CInhibitHardwareReads: I2C inhibit set.\n");
+#endif
+	}
+
+
+#ifdef AJALinux
+	up(&pNTV2Params->_I2CMutex);
+#endif
+
+	return retVal;
+}
+
+
+/*****************************************************************************************
+ *	I2CEnableHardwareReads
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CEnableHardwareReads(ULWord deviceNumber)
+#else
+static bool I2CEnableHardwareReads(ULWord deviceNumber)
+#endif
+{
+	bool retVal = true;
+
+#ifdef AJALinux
+	NTV2PrivateParams *pNTV2Params;
+
+	pNTV2Params = getNTV2Params(deviceNumber);
+
+	if(down_interruptible(&pNTV2Params->_I2CMutex))
+		return false;	
+#endif
+
+#ifdef AJAMac
+	// We're assuming that this will only be called from INSIDE the IOCommandGate, so we're already protected from preemption
+#endif
+
+
+	if(!I2CWriteControl(deviceNumber, 0))		// Inhibit I2C status register reads at vertical
+	{		 
+		retVal = false;
+	}
+
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CEnableHardwareReads: I2C inhibit cleared.\n");
+#endif
+
+#ifdef AJALinux
+	up(&pNTV2Params->_I2CMutex);
+#endif
+
+	return retVal;
+}
+
+
+/*****************************************************************************************
+ *	I2CWriteDataDoublet
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CWriteDataDoublet(	ULWord deviceNumber,
+										UByte I2CAddress1, UByte I2CData1,
+										UByte I2CAddress2, UByte I2CData2)
+#else
+bool I2CWriteDataDoublet(	ULWord deviceNumber,
+							UByte I2CAddress1, UByte I2CData1,
+							UByte I2CAddress2, UByte I2CData2)
+#endif
+{
+	bool retVal = true;
+	ULWord I2CCommand;
+
+	if (!I2CInhibitHardwareReads(deviceNumber))
+	{
+		retVal = false;
+		goto bail;
+	}
+
+	I2CCommand = I2CAddress1;
+	I2CCommand <<= 8;
+	I2CCommand |= I2CData1;
+	if (!I2CWriteData(deviceNumber, I2CCommand))
+	{		 
+		retVal = false;
+		goto bail;
+	}
+
+	I2CCommand = I2CAddress2;
+	I2CCommand <<= 8;
+	I2CCommand |= I2CData2;
+	if(!I2CWriteData(deviceNumber, I2CCommand))
+	{
+		retVal = false;
+		goto bail;
+	}
+
+bail:
+	if(!I2CEnableHardwareReads(deviceNumber))
+		retVal = false;
+
+	return retVal;
+}
+
+
+/*****************************************************************************************
+ *	WaitForI2CReady
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::WaitForI2CReady(ULWord deviceNumber)
+#else
+static bool WaitForI2CReady(ULWord deviceNumber)
+#endif
+{
+	ULWord registerValue;
+	
+#ifdef AJALinux
+	unsigned long timeoutJiffies, deadline;	// ULWord typedef makes time_before() issue bogus warnings.
+#endif
+
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("WaitForI2CReady: Waiting...\n");
+#endif
+
+#ifdef AJALinux
+	// Round up to granularity of HZ
+	timeoutJiffies = ntv2_getRoundedUpTimeoutJiffies(10);	// Timeout after 10 msec
+	deadline = jiffies + timeoutJiffies;
+
+	// Busy wait.  If I2C busy, write should complete in about 100 usec, unless something
+	// is very broken.
+	do 
+	{
+		registerValue = ReadRegister(deviceNumber, kRegI2CWriteControl, NO_MASK, NO_SHIFT);
+		if ((registerValue & BIT(31)) == 0)	// Not busy?
+		{
+#ifdef ENABLE_DEBUG_PRINT
+			if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+				MSG("WaitForI2CReady: Got ready.\n");
+#endif
+			return true;
+		}
+	} while( time_before( jiffies, deadline));
+
+#endif
+
+#ifdef AJAMac
+	int maxMSecs = 10;		// we'll wait a maximum of 10 msec
+	do
+	{
+		ReadRegisterImmediate(kRegI2CWriteControl, (uint32_t *)&registerValue);
+		if ((registerValue & BIT(31)) == 0)	// Not busy?
+		{
+//			if (maxMSecs < 10)
+//				IOLog("WaitForI2CReady: waited %d msecs for I2C Ready.\n", maxMSecs);
+			return true;
+		}
+			
+		IOSleep(1);				// sleep 1 msec & try again
+	} while (--maxMSecs > 0);
+
+#endif
+
+#ifdef ENABLE_DEBUG_PRINT
+	if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+		MSG("WaitForI2CReady: Timed out.\n");
+#endif
+
+	return false;	// Timed out, + not implemented for Windows yet.
+}
+
+
+/*****************************************************************************************
+ *	I2CWriteData
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CWriteData(ULWord deviceNumber, ULWord value)
+#else
+static bool I2CWriteData(ULWord deviceNumber, ULWord value)
+#endif
+{
+
+		// wait for the hardware to be ready
+	if (WaitForI2CReady(deviceNumber) == false)
+	{
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CWriteData: First WaitForI2CReady() failed.\n");
+#endif
+		return false;
+	}
+	
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CWriteData: writing register 0x%02x = 0x%02x  (device #%d)\n", (value & 0xFF00) >> 8, (value & 0xFF), deviceNumber);
+#endif
+
+	
+		// write the data to the hardware
+#ifdef AJALinux
+	WriteRegister(	deviceNumber,
+	  				kRegI2CWriteData, 
+					value,
+					NO_MASK,
+					NO_SHIFT);
+#endif
+
+#ifdef AJAMac
+	WriteRegisterImmediate(kRegI2CWriteData, value);
+#endif
+
+
+		// wait for the I2C to complete writing
+	if (WaitForI2CReady(deviceNumber) == false) {
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CWriteData: Second WaitForI2CReady() failed.\n");
+#endif
+		return false;
+	}
+	
+#if defined(AJALinux) || defined(AJAMac)
+	return true;
+#else
+	return false;	// Not implemented for Windows yet.
+#endif
+}
+
+
+/*****************************************************************************************
+ *	I2CWriteControl
+ *****************************************************************************************/
+#ifdef AJAMac
+bool MacDriver::I2CWriteControl(ULWord deviceNumber, ULWord value)
+#else
+static bool I2CWriteControl(ULWord deviceNumber, ULWord value)
+#endif
+{
+#ifdef ENABLE_DEBUG_PRINT
+		if (MsgsEnabled(NTV2_DRIVER_I2C_DEBUG_MESSAGES))
+			MSG("I2CWriteControl: writing 0x%08x to device #%d.\n", value, deviceNumber);
+#endif
+
+#ifdef AJALinux
+	WriteRegister(	deviceNumber,
+	  				kRegI2CWriteControl, 
+					value,
+					NO_MASK,
+					NO_SHIFT);
+	return true;
+#endif
+
+#ifdef AJAMac
+	return WriteRegisterImmediate(kRegI2CWriteControl, value);
+#endif
+
+
+	return false;	// Not implemented for Windows yet.
+}
+
+#endif	//	defined(NTV2_BUILDING_DRIVER)

--- a/ajalibraries/ajantv2/src/ntv2dynamicdevice.cpp
+++ b/ajalibraries/ajantv2/src/ntv2dynamicdevice.cpp
@@ -175,8 +175,10 @@ bool CNTV2Card::LoadDynamicDevice (const NTV2DeviceID inDeviceID)
 		currentBitfileVersion	= 0xff; // ignores bitfile version
 	}
 
-	if (!currentDesignID)
-		{DDFAIL("Current design ID is zero for " << oldDevName);  return false;}
+	if (currentDesignID == 0)
+	{
+		return false;
+	}
 
 	//	Get the clear file matching current bitfile...
 	NTV2_POINTER clearStream;

--- a/ajalibraries/ajantv2/src/ntv2mailbox.cpp
+++ b/ajalibraries/ajantv2/src/ntv2mailbox.cpp
@@ -94,8 +94,11 @@ bool CNTV2MailBox::sendMsg(uint32_t timeout)
 bool CNTV2MailBox::sendMsg(char * msg, uint32_t timeout)
 {
 	// make local safe copy
-	strncpy((char*)txBuf,msg,sizeof(txBuf));
-
+	char *const t = (char*)txBuf;
+	
+	strncpy(t, msg, sizeof(txBuf) - 1);
+	t[sizeof(txBuf) - 1] = '\0';
+	
 	return sendMsg(timeout);
 }
 

--- a/ajalibraries/ajantv2/src/ntv2nubpktcom.cpp
+++ b/ajalibraries/ajantv2/src/ntv2nubpktcom.cpp
@@ -244,8 +244,12 @@ NTV2NubPkt * BuildNubBasePacket (NTV2NubProtocolVersion protocolVersion,
 	pPkt->hdr.dataLength		= dataSize;
 
 	char *p (reinterpret_cast<char*>(pPkt->data));	// Work around ISO C++ forbids zero-size array
-	ULWord len (ULWord(::strlen(queryRespStr)) + 1);
-	::strncpy(p, queryRespStr, len);	// Copy in query/resp string incl. terminating null
+	
+	constexpr const size_t len = sizeof(pPkt->data);
+	
+	::strncpy(p, queryRespStr, len - 1); 	// Copy in query/resp string incl. terminating null
+	p[len - 1] = '\0';
+	
 	p += len;
 	*pPayload = p;
 	return pPkt;

--- a/ajalibraries/ajantv2/src/ntv2publicinterface.cpp
+++ b/ajalibraries/ajantv2/src/ntv2publicinterface.cpp
@@ -859,7 +859,7 @@ ostream & operator << (ostream & inOutStream, const NTV2RegisterValueMap & inObj
 	inOutStream << "RegValues:" << inObj.size () << "[";
 	while (iter != inObj.end ())
 	{
-		const NTV2RegisterNumber	registerNumber	(static_cast <const NTV2RegisterNumber> (iter->first));
+		const NTV2RegisterNumber	registerNumber	(static_cast <NTV2RegisterNumber> (iter->first));
 		const ULWord				registerValue	(iter->second);
 		inOutStream << ::NTV2RegisterNumberToString (registerNumber) << "=0x" << hex << registerValue << dec;
 		if (++iter != inObj.end ())
@@ -2309,7 +2309,8 @@ bool AUTOCIRCULATE_TRANSFER::SetOutputTimeCodes (const NTV2TimeCodes & inValues)
 
 	for (UWord ndx (0);	 ndx < UWord(maxNumValues);	 ndx++)
 	{
-		const NTV2TCIndex		tcIndex (static_cast<const NTV2TCIndex>(ndx));
+		const NTV2TCIndex		tcIndex	(static_cast<NTV2TCIndex>(ndx));
+
 		NTV2TimeCodesConstIter	iter	(inValues.find(tcIndex));
 		pArray[ndx] = (iter != inValues.end())	?  iter->second	 :	INVALID_TIMECODE_VALUE;
 	}	//	for each possible NTV2TCSource value

--- a/ajalibraries/ajantv2/src/ntv2registerexpert.cpp
+++ b/ajalibraries/ajantv2/src/ntv2registerexpert.cpp
@@ -3234,7 +3234,8 @@ private:
 	struct DecodeHDMIOutputStatus : public Decoder
 	{
 		virtual string operator()(const uint32_t inRegNum, const uint32_t inRegValue, const NTV2DeviceID inDeviceID) const
-		{	(void) inRegNum; (void) inDeviceID;
+		{	(void) inRegNum;
+			(void)inDeviceID;
 			const NTV2HDMIOutputStatus stat (inRegValue);
 			ostringstream	oss;
 			stat.Print(oss);
@@ -3329,7 +3330,10 @@ private:
 	struct DecodeHDMIOutMRControl : public Decoder
 	{
 		virtual string operator()(const uint32_t inRegNum, const uint32_t inRegValue, const NTV2DeviceID inDeviceID) const
-		{	(void) inRegNum;  (void) inDeviceID;
+		{
+			(void) inRegNum;
+			(void) inDeviceID;
+
 			ostringstream	oss;
 			static const string sMRStandard[]	=	{	"1080i",	"720p", "480i", "576i", "1080p",	"1556i",	"2Kx1080p", "2Kx1080i", "UHD",	"4K", "", "", "", "", "", "" };
 			const ULWord	rawVideoStd		(inRegValue & kRegMaskMRStandard);

--- a/ajalibraries/ajantv2/src/ntv2transcode.cpp
+++ b/ajalibraries/ajantv2/src/ntv2transcode.cpp
@@ -283,7 +283,7 @@ void ConvertLinetoRGB(UByte * ycbcrBuffer,
 					  bool fUseSDMatrix,
 					  bool fUseSMPTERange)
 {
-	YCbCrAlphaPixel ycbcrPixel;
+	YCbCrAlphaPixel ycbcrPixel{};
 	UWord Cb1,Y1,Cr1,Cb2,Y2,Cr2;
 
 	// take a line(CbYCrYCbYCrY....) to RGBAlphaPixels.

--- a/ajalibraries/ajantv2/src/ntv2utils.cpp
+++ b/ajalibraries/ajantv2/src/ntv2utils.cpp
@@ -9112,6 +9112,10 @@ string PercentDecode (const string & inStr)
 					hexNum += unsigned(chr + 10 - 'a');
 				else if (chr >= '0'	 &&	 chr <= '9')
 					hexNum += unsigned(chr - '0');
+				else
+				{
+				}
+
 				oss << char(hexNum);
 				hexNum = 0;
 				state = 0;


### PR DESCRIPTION
So this is rolled into one commit, I tried to keep the working tree as clean as possible.

The following is done here:

- MIT-licensed missing files added to repository from 16.2 SDK package
- Fixed compile error for Linux driver due to missing stddef.h.
- Various cleanups of strncpy() usage that could occasionally cause corruption -- strncpy() is terrible, just terrible.

NOTE: Apparently CMake build of the kernel module is still fouled up, looking at the CMakeLists.txt it looks like you're missing the .ko target. So, in the meantime, the Makefile stuff works.

Thanks!