### PR TITLE
cmake: Remove include(GNUInstallDirs) from CommonVars

### DIFF
--- a/cmake/CommonVars.cmake
+++ b/cmake/CommonVars.cmake
@@ -1,5 +1,3 @@
-include(GNUInstallDirs)
-
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(AJA_BITS 64)
     message(STATUS "Bits: 64-bit")


### PR DESCRIPTION
This include is now in the top-level CMakeLists