### PR TITLE
Create device nodes during Linux driver load

### DIFF
--- a/ajadriver/linux/Makefile
+++ b/ajadriver/linux/Makefile
@@ -41,6 +41,10 @@ else
 endif
 endif
 
+ifdef AJA_CREATE_DEVICE_NODES
+	EXTRA_CFLAGS += -DAJA_CREATE_DEVICE_NODES=$(AJA_CREATE_DEVICE_NODES)
+endif
+
 DRIVERSRCS = ntv2devicefeatures.c \
 			ntv2driver.c \
 			ntv2driverautocirculate.c \

--- a/ajadriver/linux/registerio.h
+++ b/ajadriver/linux/registerio.h
@@ -97,6 +97,7 @@ typedef struct ntv2_module_private
 	char *	name;
 	char *	driverName;
 	ULWord	intrBitLut[eNumInterruptTypes];
+	struct class *class;
 
 	// uart driver
 	struct uart_driver 			*uart_driver;
@@ -240,6 +241,7 @@ typedef struct ntv2_private
 	ULWord busNumber;
 	ULWord pci_device;
 	char name[16];
+	struct cdev cdev;
 
 	// Base Address Values
 	unsigned long _unmappedBAR0Address;


### PR DESCRIPTION
This adds an AJA_CREATE_DEVICE_NODES build option to the Linux kernel driver, which causes the driver to create the device nodes when the driver is loaded instead of needing to use mknod (via the load_ajantv2 script) to manually create the nodes.

This feature is disabled by default, and the previous `load/unload_ajantv2` scripts are still used in this case.