### PR TITLE
Only install cmake source files on AJA_INSTALL_SOURCES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if (AJA_BUILD_NONAJA AND EXISTS ${NON_AJA_ROOT})
 endif()
 
 # Install NTV2 CMake files
-if (AJA_INSTALL_HEADERS OR AJA_INSTALL_SOURCES)
+if (AJA_INSTALL_SOURCES)
     install(FILES cmake/AJABuildOptions.cmake                DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake)
     install(FILES cmake/AJACommonDefines.cmake               DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake)
     install(FILES cmake/AJACommonFlags.cmake                 DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake)


### PR DESCRIPTION
## Issue
### Steps to reproduce
```sh
git clone https://github.com/aja-video/ntv2.git src
cmake -S src -B build \
  -D AJA_INSTALL_HEADERS:BOOL=ON \
  -D AJA_INSTALL_SOURCES:BOOL=OFF
cmake --build build -j
cmake --install build --prefix $PWD/install`
```

### Error log
```log
CMake Error at build/cmake_install.cmake:54 (file):
  file INSTALL cannot set permissions on
  "/usr/local/cmake/AJABuildOptions.cmake": Operation not permitted.
```

## Expected behavior

Installing headers along with generated libraries to a custom directory with user permissions is a common use case which should succeed without the need to install CMake source files, nor use `sudo` to do it.

## Fix

- **Proposed**: Do not install CMake source files when only installing headers
- **Additional improvement** (follow-up PR?): Do not hardcode an absolute install path during the build step using `CMAKE_INSTALL_PREFIX` (defaulting to /usr/local), since it ignores the one provided by `--prefix` during `cmake --install`.


