### PR TITLE
Add MODULE_DEVICE_TABLE to autoload ajantv2 when PCIe hardware is attached

### DIFF
--- a/ajadriver/linux/ntv2driver.c
+++ b/ajadriver/linux/ntv2driver.c
@@ -455,6 +455,10 @@ static struct pci_device_id pci_device_id_tab[] =
 	{ 0, 0, 0, 0, 0, 0, 0 }								// Array terminator
 };
 
+#if defined(AJA_CREATE_DEVICE_NODES)
+MODULE_DEVICE_TABLE(pci, pci_device_id_tab);
+#endif
+
 static struct pci_driver ntv2_driver;
 
 static int reboot_handler(struct notifier_block *this, unsigned long code, void *x);


### PR DESCRIPTION
With the autocreation of the nodes and this, the NTV2 driver no longer needs `load_ajantv2` and `unload_ajantv2`. I have only tested this on one machine so your experience may vary 😄 .