### PR TITLE
Replace usage of obsolete pci-dma-compat.h API

### DIFF
--- a/ajadriver/linux/ntv2driver.c
+++ b/ajadriver/linux/ntv2driver.c
@@ -4388,9 +4388,9 @@ pci_resources_config (struct pci_dev *pdev, NTV2PrivateParams * ntv2pp)
 	// a 64-bit mask from a previous driver load.
 
 #if defined(DMA_BIT_MASK)
-	if((res = pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) != 0)
+	if((res = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) != 0)
 #else
-	if((res = pci_set_dma_mask(pdev, DMA_32BIT_MASK)) != 0)
+	if((res = dma_set_mask(&pdev->dev, DMA_32BIT_MASK)) != 0)
 #endif
 	{
 	   MSG("%s: Unable to set DMA mask.  Disabling this board.\n",
@@ -4694,9 +4694,9 @@ dma_registers_init (struct pci_dev *pdev, NTV2PrivateParams * ntv2pp)
 	}
 
 #if defined(DMA_BIT_MASK)
-	if(!pci_set_dma_mask(pdev, DMA_BIT_MASK(64)))
+	if(!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64)))
 #else
-	if(!pci_set_dma_mask(pdev, DMA_64BIT_MASK))
+	if(!dma_set_mask(&pdev->dev, DMA_64BIT_MASK))
 #endif
 	{
 		MSG("%s: Using 64-bit DMA mask with 64-bit capable firmware\n",

--- a/ajadriver/ntv2system.c
+++ b/ajadriver/ntv2system.c
@@ -1513,7 +1513,7 @@ bool ntv2DmaMemoryAlloc(Ntv2DmaMemory* pDmaMemory, Ntv2SystemContext* pSysCon, u
 	   (pSysCon->pDevice == NULL) ||
 	   (size == 0)) return false;
 
-	pAddress = pci_alloc_consistent(pSysCon->pDevice, size, &dmaAddress);
+	pAddress = dma_alloc_coherent(&pSysCon->pDevice->dev, size, &dmaAddress, GFP_ATOMIC);
 	if((pAddress == NULL) || (dmaAddress == 0)) return false;
 
 	// initialize memory data structure
@@ -1534,7 +1534,7 @@ void ntv2DmaMemoryFree(Ntv2DmaMemory* pDmaMemory)
 	   (pDmaMemory->dmaAddress == 0) ||
 	   (pDmaMemory->size == 0)) return;
 
-	pci_free_consistent(pDmaMemory->pDevice,
+	dma_free_coherent(&pDmaMemory->pDevice->dev,
 						pDmaMemory->size,
 						pDmaMemory->pAddress,
 						pDmaMemory->dmaAddress);


### PR DESCRIPTION
This API has not been recommended for a number
of years, and was finally removed from kernel 5.18